### PR TITLE
test: do not run tests when inside containers/CI as it won't work

### DIFF
--- a/test/usb.coffee
+++ b/test/usb.coffee
@@ -2,6 +2,10 @@ assert = require('assert')
 util = require('util')
 usb = require("../usb.js")
 
+if process.env.CI
+	console.log 'Tests cannot be run inside containers/CI.'
+	process.exit 0
+
 if typeof gc is 'function'
 	# running with --expose-gc, do a sweep between tests so valgrind blames the right one
 	afterEach -> gc()


### PR DESCRIPTION
Tests won't work as `libusb` won't be able to initialize when run in containers. Check for the presence of the `CI` environment variable which is the default to signal that it's running in a CI environment, and thus likely in container.

* Appveyor: https://www.appveyor.com/docs/environment-variables/
* CircleCI: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
* GitLab CI: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html#variables-reference
* Travis CI: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>